### PR TITLE
fix: otlp exporter version constraint

### DIFF
--- a/otel_log_wrapper/pyproject.toml
+++ b/otel_log_wrapper/pyproject.toml
@@ -12,7 +12,10 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ['opentelemetry-exporter-otlp', 'opentelemetry-instrumentation-logging']
+dependencies = [
+    'opentelemetry-exporter-otlp==1.33.1',
+    'opentelemetry-instrumentation-logging'
+]
 
 [project.urls]
 Homepage = "https://github.com/nosportugal/haas-python-helpers/otel_log_wrapper"


### PR DESCRIPTION
This pull request updates the dependency management in the `otel_log_wrapper` project by specifying a version for one of the dependencies.

Dependency management updates:

* [`otel_log_wrapper/pyproject.toml`](diffhunk://#diff-58fd99b2d1f6a149115db66fa278f859a30647957adbd29d34f34c4ca1b920bcL15-R18): Updated the `dependencies` section to pin the `opentelemetry-exporter-otlp` dependency to version `1.33.1`, ensuring consistent behavior across environments.