### PR TITLE
HAAS-426 Add sync confluence release workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+select = WPS

--- a/.github/workflows/build-sync-confluence.yaml
+++ b/.github/workflows/build-sync-confluence.yaml
@@ -1,0 +1,57 @@
+name: Build sync_confluence
+
+on:
+  push:
+    tags:
+      - "sync-confluence-v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install -e ./sync_confluence
+
+    - name: Run tests
+      run: |
+        cd sync_confluence
+        pytest
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+
+    - name: Build package
+      run: |
+        cd sync_confluence
+        python -m build
+
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      with:
+        files: ./sync_confluence/dist/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-toml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/wemake-services/wemake-python-styleguide
+    rev: 1.6.2
+    hooks:
+      - id: wemake-python-styleguide

--- a/sync_confluence/README.md
+++ b/sync_confluence/README.md
@@ -1,56 +1,42 @@
 # sync_confluence
 
 Syncs a `docs/` directory tree (or a flat list of Markdown files) to Confluence Cloud as a hierarchy of nested pages.
-Subdirectories are mirrored as native Confluence Folders under a configured parent page. The root `README.md` becomes the section parent page; all other `.md` files (including README.md in subfolders) become regular child pages under their respective folder. Markdown is converted to Confluence Storage Format with fenced-code macros, optional Mermaid macro support, and relative-link rewriting to GitHub blob URLs. Content-hash comparison prevents no-op updates, and an optional orphan-cleanup pass deletes pages with no matching source file.
 
-## Package structure
+- Subdirectories are mirrored as native Confluence Folders under a configured parent page.
+- The root `README.md` becomes the section parent page; all other `.md` files (including `README.md` in subfolders) become regular child pages under their respective folder.
+- Markdown is converted to Confluence Storage Format with fenced-code macros, optional Mermaid macro support, and relative-link rewriting to GitHub blob URLs.
+- Content-hash comparison prevents no-op updates, and an optional orphan-cleanup pass deletes pages with no matching source file.
 
-```markdown
-python_actions/sync_confluence/
-├── src/
-│   └── sync_confluence/
-│       ├── __init__.py
-│       ├── __main__.py
-│       ├── cli.py
-│       ├── confluence.py
-│       ├── converter.py
-│       └── traversal.py
-├── tests/
-│   ├── __init__.py
-│   ├── test_cli.py
-│   └── test_converter.py
-├── pyproject.toml
-└── README.md
-```
+## Features
 
-## Prerequisites
-
-- Python 3.11+
-- A Confluence Cloud instance with an API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens)
-- A pre-existing parent page — note its numeric page ID (visible in the page URL as `?pageId=…`)
+- CLI tool for one-way sync of Markdown docs to Confluence Cloud
+- Folder mirroring, fenced-code block and Mermaid macro support
+- Orphan cleanup with label-based page management — only pages tagged with the managed-by label are eligible for deletion
+- Rename detection: renames existing pages in place instead of creating duplicates
+- Page edit restrictions: synced pages are set to read-only for everyone except the syncing account
+- Python 3.11+ required
 
 ## Installation
 
-Install the package from the repository root:
+### Local development
 
-```sh
-pip install python_actions/sync_confluence
+From the repository root:
+
+```bash
+pip install -e sync_confluence
 ```
 
-For local development, install in editable mode:
+### CI / consumer repos
 
-```sh
-pip install -e python_actions/sync_confluence
+```bash
+pip install git+https://github.com/nosportugal/haas-python-helpers.git#subdirectory=sync_confluence
 ```
-
-Dependencies (`atlassian-python-api>=3.41.0`, `markdown>=3.7`) are declared in
-[`pyproject.toml`](pyproject.toml) and installed automatically.
 
 ## Usage
 
-### Dry run (preview, no API calls)
+### CLI Example: Dry run (preview, no API calls)
 
-```sh
+```bash
 python -m sync_confluence \
     --url  https://acme.atlassian.net \
     --email user@acme.com \
@@ -60,9 +46,9 @@ python -m sync_confluence \
     --dry-run
 ```
 
-### Live sync
+### CLI Example: Live sync
 
-```sh
+```bash
 python -m sync_confluence \
   --url  https://acme.atlassian.net \
   --email user@acme.com \
@@ -71,9 +57,9 @@ python -m sync_confluence \
   --parent-id 12345
 ```
 
-### Sync a flat list of Markdown files
+### CLI Example: Sync a flat list of Markdown files
 
-```sh
+```bash
 python -m sync_confluence \
   --url https://acme.atlassian.net \
   --email user@acme.com \
@@ -85,26 +71,9 @@ python -m sync_confluence \
 
 This mode syncs the specified files as leaf pages directly under the parent page, with no folder structure. Mutually exclusive with `--docs-dir`.
 
-### Orphan cleanup (always active)
+### CLI Example: Using environment variables
 
-**⚠️ WARNING: Every sync run PERMANENTLY DELETES Confluence pages under the parent that do not match a source file. This action is IRREVERSIBLE.**
-
-Orphan cleanup runs automatically after every sync — there is no opt-in flag.
-To prevent accidental deletion of unrelated pages, the sync script applies a label to every page it manages.
-The label is auto-derived from the git repository name (e.g. `managed-by-a3-e2e`).
-
-- You can override the label with `--managed-by <label>` or the `CONFLUENCE_MANAGED_BY` environment variable.
-- **Only pages with this label are eligible for deletion.**
-- If the label cannot be derived and `--managed-by` is not set, all unmatched pages under the parent are at risk.
-
-Use `--dry-run` to preview which pages would be deleted before running a live sync.
-
-### Using environment variables
-
-All required values can be supplied as environment variables instead of CLI flags.
-Environment variables are useful for CI/CD pipelines where secrets are injected at runtime.
-
-```sh
+```bash
 export CONFLUENCE_URL=https://acme.atlassian.net
 export CONFLUENCE_EMAIL=user@acme.com
 export CONFLUENCE_API_TOKEN=<api-token>
@@ -114,60 +83,33 @@ export CONFLUENCE_PARENT_PAGE_ID=12345
 python -m sync_confluence
 ```
 
-## Configuration reference
+### Orphan cleanup (always active)
 
-CLI flags take precedence over environment variables.
-Required flags must be supplied via one of the two mechanisms.
+**⚠️ WARNING: Every sync run PERMANENTLY DELETES Confluence pages under the parent that do not match a source file. This action is IRREVERSIBLE.**
 
-| Flag | Env var | Required | Default | Description |
-|---|---|---|---|---|
-| `--url` | `CONFLUENCE_URL` | yes | — | Confluence base URL (e.g. `https://acme.atlassian.net`) |
-| `--email` | `CONFLUENCE_EMAIL` | yes | — | Atlassian account email |
-| `--token` | `CONFLUENCE_API_TOKEN` | yes | — | API token from id.atlassian.com |
-| `--space` | `CONFLUENCE_SPACE_KEY` | yes | — | Target space key |
-| `--parent-id` | `CONFLUENCE_PARENT_PAGE_ID` | yes | — | Numeric ID of the pre-existing parent page |
-| `--docs-dir` | `DOCS_DIR` | no | auto-detect | Path to the directory to sync. If not set, auto-detects the first existing directory from `docs/`, `documentation/`, or `doc/`. |
-| `--docs-files` | — | no | — | One or more Markdown files to sync as leaf pages directly under the parent. Mutually exclusive with `--docs-dir`. |
-| `--root-title` | `CONFLUENCE_ROOT_TITLE` | no | First H1 in `docs/README.md` | Title for the root section page; mutually exclusive with `--no-root` and `--root-parent` |
-| `--managed-by` | `CONFLUENCE_MANAGED_BY` | no | derived from git repository name | Label applied to every page created/updated by this sync; only pages with this label are eligible for orphan deletion |
+Orphan cleanup runs automatically after every sync — there is no opt-in flag. The sync script applies a label (auto-derived from the git repository name, e.g. `managed-by-a3-e2e`) to every page it manages. **Only pages with this label are eligible for deletion.** Override with `--managed-by <label>` or `CONFLUENCE_MANAGED_BY`. If the label cannot be derived and `--managed-by` is not set, all unmatched pages under the parent are at risk.
 
-## Label-based page management
+## CLI Arguments & Environment Variables
 
-To safely manage and clean up only the pages owned by this repository, the sync script applies a label to every page it creates or updates. The label is auto-derived from the git repository name (e.g. `managed-by-a3-e2e` for this repo). You can override it with `--managed-by <label>` or the `CONFLUENCE_MANAGED_BY` environment variable.
+CLI flags take precedence over environment variables. Required flags must be supplied via one of the two mechanisms.
 
-Orphan cleanup runs after every sync. **Only pages with this label are eligible for deletion**, which prevents accidental removal of unrelated or manually created pages under the same parent. If the label cannot be derived and `--managed-by` is not set, all unmatched pages are at risk.
+- `--url` / `CONFLUENCE_URL`: Confluence base URL (e.g. `https://acme.atlassian.net`) — **required**
+- `--email` / `CONFLUENCE_EMAIL`: Atlassian account email — **required**
+- `--token` / `CONFLUENCE_API_TOKEN`: API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) — **required**
+- `--space` / `CONFLUENCE_SPACE_KEY`: Target space key — **required**
+- `--parent-id` / `CONFLUENCE_PARENT_PAGE_ID`: Numeric ID of the pre-existing parent page — **required**
+- `--docs-dir` / `DOCS_DIR`: Path to the docs directory to sync. Auto-detects `docs/`, `documentation/`, or `doc/` if not set
+- `--docs-files`: One or more Markdown files to sync as leaf pages directly under the parent. Mutually exclusive with `--docs-dir`
+- `--root-title` / `CONFLUENCE_ROOT_TITLE`: Title for the root section page (default: first H1 in `docs/README.md`). Mutually exclusive with `--no-root` and `--root-parent`
+- `--no-root`: Sync all files flat under `--parent-id` without a root container page. Mutually exclusive with `--root-parent` and `--root-title`
+- `--root-parent` / `CONFLUENCE_ROOT_PARENT`: Title of a container folder to find or create under `--parent-id`. Mutually exclusive with `--no-root` and `--root-title`
+- `--managed-by` / `CONFLUENCE_MANAGED_BY`: Label applied to every managed page; only these are eligible for orphan deletion (default: derived from git repository name)
+- `--git-ref` / `GITHUB_REF_NAME`: Git ref used in rewritten GitHub link URLs (default: `main`)
+- `--mermaid-macro` / `CONFLUENCE_MERMAID_MACRO`: Confluence macro name for Mermaid diagrams; omit to render as a plain code block
+- `--dry-run`: Preview pages that would be created, updated, or deleted without making any API calls
+- `--log-level` / `LOG_LEVEL`: Logging verbosity — `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`)
 
-| Flag | Env var | Required | Default | Description |
-|---|---|---|---|---|
-| `--git-ref` | `GITHUB_REF_NAME` | no | `main` | Git ref used in rewritten GitHub link URLs |
-| `--mermaid-macro` | `CONFLUENCE_MERMAID_MACRO` | no | — | Confluence macro name for Mermaid diagrams; omit to render as a plain code block |
-| `--dry-run` | — | no | off | Preview pages that would be created, updated, or deleted without making any API calls |
-
-| `--no-root` | — | no | off | Sync all files directly under `--parent-id` without a root container page; mutually exclusive with `--root-parent` and `--root-title` |
-| `--root-parent` | `CONFLUENCE_ROOT_PARENT` | no | — | Title of a container folder to find or create under `--parent-id`; all docs are synced under it as children. Always creates a Confluence Folder if not found. Mutually exclusive with `--no-root` and `--root-title` |
-| `--log-level` | `LOG_LEVEL` | no | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-
-## Rename detection
-
-When a Markdown file is renamed, the sync script updates the existing Confluence page in place instead of creating a new page and leaving a stale orphan.
-
-Every page created or updated by the script stores a `sync_confluence_source_path` page property containing its docs-root-relative source file path (e.g. `architecture/stack.md`).
-Before each sync, the script builds a `source_path → page_id` map from the existing child pages.
-If a file's source path matches a stored property — even when the derived title has changed — the original page is renamed and its content updated rather than creating a duplicate.
-
-In dry-run mode, rename detection is simulated: the script logs which pages would be renamed without making any API changes.
-
-Pages that pre-date this feature and carry no source path property fall back to title-matching only.
-
-## Page edit restrictions
-
-Every synced page is made read-only for everyone except the account whose API token is used for syncing. The script resolves the authenticated user's `accountId` once at startup and applies a `PUT /rest/api/content/{id}/restriction` call after each page creation or update (unchanged pages are skipped to avoid extra API calls).
-
-View access is never restricted — all Confluence users can still read the pages.
-
-**Note:** Until a dedicated bot account is provisioned, this will use the individual user's credentials. Once a bot account is created, update `CONFLUENCE_EMAIL` and `CONFLUENCE_API_TOKEN` to the bot's credentials; the restriction will automatically be transferred to that account on the next sync run.
-
-## Root page modes and folder mapping
+## Root page modes
 
 Three mutually exclusive modes control how the top-level structure is created. At most one of `--root-title`, `--no-root`, and `--root-parent` may be supplied.
 
@@ -187,34 +129,21 @@ A named container folder with the given title is found under `--parent-id` (or c
 - Any `README.md` inside a subdirectory becomes a regular child page under that folder, not a section parent.
 - All other `.md` files become leaf pages under their respective folder or parent.
 
-## Testing
+## Development
 
-Run the package's test suite from the repository root:
+- Format: `uv run ruff format .`
+- Lint: `uv run ruff check . --fix`
+- Tests: `uv run pytest`
 
-```sh
-pytest python_actions/sync_confluence/tests/
-```
-
-Or from within the package directory:
-
-```sh
-cd python_actions/sync_confluence
-pytest
-```
-
-Lint with ruff:
-
-```sh
-ruff check python_actions/sync_confluence/src/
-```
+Tests must not make real network calls; mock or stub all I/O.
 
 ## GitHub Actions integration
 
-The [`docs-sync.yaml`](../../.github/workflows/docs-sync.yaml) workflow triggers on every push to `main` that touches `docs/**`.
+Add the following steps to your workflow to sync docs on every push to `main`:
 
 ```yaml
 - name: Install dependencies
-  run: pip install python_actions/sync_confluence
+  run: pip install git+https://github.com/nosportugal/haas-python-helpers.git#subdirectory=sync_confluence
 
 - name: Sync to Confluence
   run: |
@@ -243,12 +172,6 @@ Required GitHub repository variables (same settings page, `Variables` tab):
 | `CONFLUENCE_SPACE_KEY` | Target space key (e.g. `DOCS`) |
 | `CONFLUENCE_PARENT_PAGE_ID` | Numeric ID of the pre-existing parent page |
 
-## Module map
+## License
 
-| Module | Responsibility |
-|---|---|
-| [`src/sync_confluence/converter.py`](src/sync_confluence/converter.py) | Markdown → Confluence Storage Format; `convert_markdown`, `derive_title` |
-| [`src/sync_confluence/confluence.py`](src/sync_confluence/confluence.py) | Confluence API operations: `upsert_page`, `upsert_folder`, `delete_orphans`, `build_source_path_map`, `_find_page_under_parent`, `_find_folder_under_parent` |
-| [`src/sync_confluence/traversal.py`](src/sync_confluence/traversal.py) | Recursive directory walk: `sync_directory`, flat file sync: `sync_files` |
-| [`src/sync_confluence/cli.py`](src/sync_confluence/cli.py) | Argument parsing (`parse_args`), validation, `run`, `main` |
-| [`src/sync_confluence/__main__.py`](src/sync_confluence/__main__.py) | Package entry point — enables `python -m sync_confluence` |
+This package is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This pull request introduces several improvements to the `sync_confluence` package, focusing on developer workflow, documentation clarity, and code quality. The most significant updates include the addition of pre-commit hooks, a new GitHub Actions workflow for building and releasing the package, the introduction of a Flake8 configuration for linting, and a comprehensive rewrite of the `README.md` to provide clearer usage instructions and development guidelines.

**Developer workflow and automation:**

* Added a GitHub Actions workflow (`.github/workflows/build-sync-confluence.yaml`) to automate testing, building, and releasing the `sync_confluence` package on tag pushes matching `sync-confluence-v*.*.*`. This workflow includes separate jobs for running tests and for building and releasing the package.
* Introduced a `.pre-commit-config.yaml` file to enable pre-commit hooks for code quality checks, formatting, and style enforcement using tools such as ruff and wemake-python-styleguide.
* Added a `.flake8` configuration file to enforce a maximum line length and select the wemake-python-styleguide ruleset.

**Documentation improvements:**

* Completely rewrote and reorganized the `sync_confluence/README.md` to clarify features, installation, usage (with CLI and environment variable examples), configuration, orphan cleanup safety, and development/testing instructions. The documentation now emphasizes label-based page management, rename detection, edit restrictions, and provides a clearer mapping of CLI flags and environment variables. [[1]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL4-R39) [[2]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL63-R51) [[3]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL74-R62) [[4]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL88-R76) [[5]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL117-R112) [[6]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL190-R146) [[7]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bL246-R177)

**Licensing:**

* Added a license section to the `README.md`, explicitly stating the package is MIT licensed.