### PR TITLE
HAAS-000 Update code quality checks and add YAML linting configurations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
 select = WPS
+per-file-ignores =
+    */__init__.py: WPS410, WPS412
+    sync_confluence/src/sync_confluence/confluence/_constants.py: WPS110, WPS115

--- a/.github/workflows/build-otel-log-wrapper.yaml
+++ b/.github/workflows/build-otel-log-wrapper.yaml
@@ -13,30 +13,30 @@ jobs:
     name: Validate otel_log_wrapper package
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Validate package
-      uses: ./.github/actions/validate-package
-      with:
-        package-dir: otel_log_wrapper
-        python-version: '3.x'
+      - name: Validate package
+        uses: ./.github/actions/validate-package
+        with:
+          package-dir: otel_log_wrapper
+          python-version: '3.x'
 
   deploy:
     name: Build and release otel_log_wrapper package
     runs-on: ubuntu-latest
     needs: validate
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Build package
-      uses: ./.github/actions/build-and-release
-      with:
-        package-dir: otel_log_wrapper
-        python-version: '3.x'
+      - name: Build package
+        uses: ./.github/actions/build-and-release
+        with:
+          package-dir: otel_log_wrapper
+          python-version: '3.x'
 
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      with:
-        files: ./otel_log_wrapper/dist/*
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: ./otel_log_wrapper/dist/*

--- a/.github/workflows/build-sync-confluence.yaml
+++ b/.github/workflows/build-sync-confluence.yaml
@@ -13,30 +13,30 @@ jobs:
     name: Validate sync_confluence package
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Validate package
-      uses: ./.github/actions/validate-package
-      with:
-        package-dir: sync_confluence
-        python-version: '3.11'
+      - name: Validate package
+        uses: ./.github/actions/validate-package
+        with:
+          package-dir: sync_confluence
+          python-version: '3.11'
 
   deploy:
     name: Build and release sync_confluence package
     runs-on: ubuntu-latest
     needs: validate
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-    - name: Build package
-      uses: ./.github/actions/build-and-release
-      with:
-        package-dir: sync_confluence
-        python-version: '3.11'
+      - name: Build package
+        uses: ./.github/actions/build-and-release
+        with:
+          package-dir: sync_confluence
+          python-version: '3.11'
 
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      with:
-        files: ./sync_confluence/dist/*
+      - name: Release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: ./sync_confluence/dist/*

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+default: true
+
+MD013: false

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  line-length:
+    max: 120
+
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]
+
+  document-start: disable


### PR DESCRIPTION
This pull request introduces configuration improvements to the project's linting and formatting tools. The changes mainly focus on customizing linting rules for Python, Markdown, and YAML files to better fit the project's needs.

Linting and formatting configuration updates:

* Updated `.flake8` to add per-file ignores for specific warning codes in `__init__.py` and `_constants.py`, reducing unnecessary linting errors for those files.
* Added `.markdownlint.yaml` to enable default rules and disable the MD013 rule (line length) for Markdown files.
* Added `.yamllint.yaml` with custom rules, including increasing the maximum line length to 120, specifying allowed truthy values, and disabling the document start rule for YAML files.