### PR TITLE
HAAS-000 Add support for attachments and Mermaid diagram rendering

### DIFF
--- a/sync_confluence/README.md
+++ b/sync_confluence/README.md
@@ -113,11 +113,44 @@ CLI flags take precedence over environment variables. Required flags must be sup
 - `--managed-by` / `CONFLUENCE_MANAGED_BY`: Label applied to every managed page; only these are eligible for orphan deletion (default: derived from git repository name)
 - `--git-ref` / `GITHUB_REF_NAME`: Git ref used in rewritten GitHub link URLs (default: `main`)
 - `--mermaid-macro` / `CONFLUENCE_MERMAID_MACRO`: Confluence macro name for Mermaid diagrams; omit to render as a plain code block
+- `--upload-attachments` / `UPLOAD_ATTACHMENTS`: Upload local PNG/JPEG images and rendered Mermaid diagrams as Confluence page attachments. Requires `mmdc` for diagram rendering
+- `--mmdc-path` / `MMDC_PATH`: Path to the `mmdc` CLI binary. Auto-detected on `PATH` when not set. Only relevant with `--upload-attachments`
 - `--page-width` / `CONFLUENCE_PAGE_WIDTH`: Set display width for every synced page.
   `full-width` enables wide layout; `default` enforces standard Confluence width.
   Omit to leave page widths unchanged
 - `--dry-run`: Preview pages that would be created, updated, or deleted without making any API calls
 - `--log-level` / `LOG_LEVEL`: Logging verbosity — `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`)
+
+## Diagram and image attachment upload
+
+When `--upload-attachments` is set, `sync_confluence` uploads assets directly to
+Confluence pages instead of embedding external references:
+
+- **Mermaid diagrams** — ` ```mermaid ``` ` fenced blocks are rendered to SVG via the
+  `mmdc` CLI and uploaded as page attachments.  The fenced block is replaced with an
+  inline `<ac:image>` referencing the attachment.
+- **Local images** — `![alt](./relative/path.png)` references resolved relative to the
+  Markdown file are uploaded as attachments.  PNG and JPEG files are supported;
+  other formats are skipped with a `DEBUG` log.
+
+### Installing mmdc
+
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+If `mmdc` is not found on `PATH` at startup, a single `WARNING` is logged and Mermaid
+blocks fall back to plain code blocks for the entire run.  Local image upload is
+unaffected by the availability of `mmdc`.
+
+### Known limitations
+
+- Attachments are only (re-)uploaded when the page action is `created` or `updated`.
+  A page synced before `--upload-attachments` was enabled will not receive attachments
+  until its Markdown source changes.
+- Only PNG and JPEG local images are supported; SVG and other formats are skipped.
+- Changes to attachment byte-content (e.g. a new version of `mmdc` producing different
+  SVG output) are not detected independently of the page body hash.
 
 ## Root page modes
 

--- a/sync_confluence/README.md
+++ b/sync_confluence/README.md
@@ -85,9 +85,16 @@ python -m sync_confluence
 
 ### Orphan cleanup (always active)
 
-**⚠️ WARNING: Every sync run PERMANENTLY DELETES Confluence pages under the parent that do not match a source file. This action is IRREVERSIBLE.**
+**⚠️ WARNING: Every sync run PERMANENTLY DELETES Confluence pages under the parent
+that do not match a source file. This action is IRREVERSIBLE.**
 
-Orphan cleanup runs automatically after every sync — there is no opt-in flag. The sync script applies a label (auto-derived from the git repository name, e.g. `managed-by-a3-e2e`) to every page it manages. **Only pages with this label are eligible for deletion.** Override with `--managed-by <label>` or `CONFLUENCE_MANAGED_BY`. If the label cannot be derived and `--managed-by` is not set, all unmatched pages under the parent are at risk.
+Orphan cleanup runs automatically after every sync — there is no opt-in flag.
+The sync script applies a label (auto-derived from the git repository name,
+e.g. `managed-by-a3-e2e`) to every page it manages.
+**Only pages with this label are eligible for deletion.**
+Override with `--managed-by <label>` or `CONFLUENCE_MANAGED_BY`.
+If the label cannot be derived and `--managed-by` is not set,
+all unmatched pages under the parent are at risk.
 
 ## CLI Arguments & Environment Variables
 
@@ -106,6 +113,9 @@ CLI flags take precedence over environment variables. Required flags must be sup
 - `--managed-by` / `CONFLUENCE_MANAGED_BY`: Label applied to every managed page; only these are eligible for orphan deletion (default: derived from git repository name)
 - `--git-ref` / `GITHUB_REF_NAME`: Git ref used in rewritten GitHub link URLs (default: `main`)
 - `--mermaid-macro` / `CONFLUENCE_MERMAID_MACRO`: Confluence macro name for Mermaid diagrams; omit to render as a plain code block
+- `--page-width` / `CONFLUENCE_PAGE_WIDTH`: Set display width for every synced page.
+  `full-width` enables wide layout; `default` enforces standard Confluence width.
+  Omit to leave page widths unchanged
 - `--dry-run`: Preview pages that would be created, updated, or deleted without making any API calls
 - `--log-level` / `LOG_LEVEL`: Logging verbosity — `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`)
 

--- a/sync_confluence/src/sync_confluence/cli/_args.py
+++ b/sync_confluence/src/sync_confluence/cli/_args.py
@@ -85,6 +85,25 @@ def _add_sync_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--upload-attachments",
+        action="store_true",
+        default=_env("UPLOAD_ATTACHMENTS", "").lower() in ("1", "true", "yes"),
+        help=(
+            "Upload local PNG/JPEG images and rendered Mermaid diagrams as "
+            "Confluence page attachments.  Requires mmdc for diagram rendering "
+            "(env: UPLOAD_ATTACHMENTS)."
+        ),
+    )
+    parser.add_argument(
+        "--mmdc-path",
+        default=_env("MMDC_PATH"),
+        help=(
+            "Path to the mmdc CLI binary used to render Mermaid diagrams to SVG. "
+            "Auto-detected on PATH when not set.  Only relevant with "
+            "--upload-attachments (env: MMDC_PATH)."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Preview pages that would be created/updated/deleted.",

--- a/sync_confluence/src/sync_confluence/cli/_args.py
+++ b/sync_confluence/src/sync_confluence/cli/_args.py
@@ -128,6 +128,18 @@ def _add_meta_args(parser: argparse.ArgumentParser) -> None:
         default=_env("LOG_LEVEL", "INFO"),
         help="Logging verbosity (env: LOG_LEVEL, default: INFO).",
     )
+    parser.add_argument(
+        "--page-width",
+        default=_env("CONFLUENCE_PAGE_WIDTH"),
+        choices=["full-width", "default"],
+        help=(
+            "Display width for every synced page. "
+            "'full-width' enables wide layout; "
+            "'default' enforces standard Confluence width. "
+            "Omit to leave page widths unchanged "
+            "(env: CONFLUENCE_PAGE_WIDTH)."
+        ),
+    )
 
 
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
@@ -142,7 +154,6 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
 
 
 def validate_args(args: argparse.Namespace) -> None:
-    """Exit with code 2 if any required argument is missing."""
     missing = []
     for attr, label in (
         ("url", "--url / CONFLUENCE_URL"),
@@ -171,4 +182,11 @@ def validate_args(args: argparse.Namespace) -> None:
 
     if args.docs_dir and getattr(args, "docs_files", None):
         log.error("--docs-dir and --docs-files are mutually exclusive.")
+        sys.exit(2)
+
+    if args.page_width not in (None, "full-width", "default"):
+        log.error(
+            "Invalid --page-width '%s'; valid values: full-width, default",
+            args.page_width,
+        )
         sys.exit(2)

--- a/sync_confluence/src/sync_confluence/cli/_dispatch.py
+++ b/sync_confluence/src/sync_confluence/cli/_dispatch.py
@@ -30,6 +30,7 @@ def _build_sync_context(
         dry_run=args.dry_run,
         managed_by_label=auth.managed_by_label,
         restrict_edits_to=auth.restrict_edits_to,
+        page_width=args.page_width,
     )
 
 

--- a/sync_confluence/src/sync_confluence/cli/_dispatch.py
+++ b/sync_confluence/src/sync_confluence/cli/_dispatch.py
@@ -14,11 +14,16 @@ from sync_confluence.traversal import (
     sync_directory,
     sync_files,
 )
+from sync_confluence.traversal._diagrams import find_mmdc
 
 
 def _build_sync_context(
     args: argparse.Namespace, docs: _DocsInfo, auth: _AuthInfo
 ) -> SyncContext:
+    upload_attachments: bool = getattr(args, "upload_attachments", False)
+    mmdc_path = (
+        find_mmdc(getattr(args, "mmdc_path", None)) if upload_attachments else None
+    )
     return SyncContext(
         confluence=auth.confluence,
         space_key=args.space,
@@ -31,6 +36,8 @@ def _build_sync_context(
         managed_by_label=auth.managed_by_label,
         restrict_edits_to=auth.restrict_edits_to,
         page_width=args.page_width,
+        upload_attachments=upload_attachments,
+        mmdc_path=mmdc_path,
     )
 
 

--- a/sync_confluence/src/sync_confluence/confluence/__init__.py
+++ b/sync_confluence/src/sync_confluence/confluence/__init__.py
@@ -10,6 +10,7 @@ single-module layout):
 - :func:`delete_orphans` — bottom-up cleanup of stale pages and folders.
 """
 
+from sync_confluence.confluence._attachment import upsert_attachment
 from sync_confluence.confluence._cleanup import delete_orphans
 from sync_confluence.confluence._folder_upsert import upsert_folder
 from sync_confluence.confluence._page_upsert import upsert_page
@@ -26,6 +27,7 @@ __all__ = [
     "PageUpsertRequest",
     "build_source_path_map",
     "delete_orphans",
+    "upsert_attachment",
     "upsert_folder",
     "upsert_page",
 ]

--- a/sync_confluence/src/sync_confluence/confluence/_attachment.py
+++ b/sync_confluence/src/sync_confluence/confluence/_attachment.py
@@ -1,0 +1,96 @@
+"""Confluence attachment upsert — create or update a page attachment."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from atlassian import Confluence
+
+log = logging.getLogger(__name__)
+
+_DRY_RUN_ID = "DRY-RUN"
+
+
+def upsert_attachment(  # noqa: WPS211 — six args matches the Confluence API shape
+    confluence: Confluence,
+    page_id: str,
+    filename: str,
+    raw_bytes: bytes,
+    content_type: str,
+    *,
+    dry_run: bool = False,
+) -> str:
+    """Upload *data* as an attachment named *filename* on *page_id*.
+
+    If an attachment with the same filename already exists it is updated
+    in-place.  Returns the attachment ID (or ``"DRY-RUN"`` in dry-run mode).
+    """
+    if dry_run:
+        log.info("[DRY-RUN] Would upload attachment %s to page %s", filename, page_id)
+        return _DRY_RUN_ID
+
+    existing_id = _find_attachment_id(confluence, page_id, filename)
+    if existing_id:
+        return _update_attachment(
+            confluence, page_id, existing_id, filename, raw_bytes, content_type
+        )
+    return _create_attachment(confluence, page_id, filename, raw_bytes, content_type)
+
+
+def _find_attachment_id(
+    confluence: Confluence, page_id: str, filename: str
+) -> Optional[str]:
+    """Return the attachment ID for *filename* on *page_id*, or ``None``."""
+    # Any: atlassian-python-api client has no type stubs
+    api_resp = confluence.get_attachments_from_content(  # type: ignore[attr-defined]
+        page_id, filename=filename, limit=1
+    )
+    att_items = api_resp.get("results", [])
+    if att_items:
+        return str(att_items[0]["id"])
+    return None
+
+
+def _create_attachment(
+    confluence: Confluence,
+    page_id: str,
+    filename: str,
+    raw_bytes: bytes,
+    content_type: str,
+) -> str:
+    """POST a new attachment; return its ID."""
+    # Any: atlassian-python-api returns untyped dicts
+    api_resp = confluence.attach_content(  # type: ignore[attr-defined]
+        content=raw_bytes,
+        name=filename,
+        content_type=content_type,
+        page_id=page_id,
+    )
+    attachment_id = str(api_resp["results"][0]["id"])
+    log.debug(
+        "Created attachment %s (id=%s) on page %s", filename, attachment_id, page_id
+    )
+    return attachment_id
+
+
+def _update_attachment(  # noqa: WPS211 — six args matches the Confluence API shape
+    confluence: Confluence,
+    page_id: str,
+    attachment_id: str,
+    filename: str,
+    raw_bytes: bytes,
+    content_type: str,
+) -> str:
+    """PUT updated content for an existing attachment; return its ID."""
+    confluence.update_attachment(  # type: ignore[attr-defined]
+        page_id=page_id,
+        attachment_id=attachment_id,
+        content=raw_bytes,
+        name=filename,
+        content_type=content_type,
+    )
+    log.debug(
+        "Updated attachment %s (id=%s) on page %s", filename, attachment_id, page_id
+    )
+    return attachment_id

--- a/sync_confluence/src/sync_confluence/confluence/_constants.py
+++ b/sync_confluence/src/sync_confluence/confluence/_constants.py
@@ -33,3 +33,5 @@ class _Actions:
 _DRY_RUN_ID = "DRY-RUN"
 _HASH_PROPERTY_KEY = "sync_confluence_hash"
 _SOURCE_PATH_PROPERTY_KEY = "sync_confluence_source_path"
+_APPEARANCE_PUBLISHED_KEY = "content-appearance-published"
+_APPEARANCE_DRAFT_KEY = "content-appearance-draft"

--- a/sync_confluence/src/sync_confluence/confluence/_page_metadata.py
+++ b/sync_confluence/src/sync_confluence/confluence/_page_metadata.py
@@ -7,6 +7,8 @@ from typing import Optional
 from atlassian import Confluence
 
 from sync_confluence.confluence._constants import (
+    _APPEARANCE_DRAFT_KEY,
+    _APPEARANCE_PUBLISHED_KEY,
     _HASH_PROPERTY_KEY,
     _SOURCE_PATH_PROPERTY_KEY,
 )
@@ -36,6 +38,21 @@ def _apply_page_metadata(
         _apply_label(confluence, page_id, request.managed_by_label)
     if request.restrict_edits_to:
         _apply_edit_restriction(confluence, page_id, request.restrict_edits_to)
+    if request.page_width is not None:
+        _try_property_set(
+            confluence,
+            page_id,
+            _APPEARANCE_PUBLISHED_KEY,
+            request.page_width,
+            "appearance",
+        )
+        _try_property_set(
+            confluence,
+            page_id,
+            _APPEARANCE_DRAFT_KEY,
+            request.page_width,
+            "appearance",
+        )
 
 
 def _log_dry_run_metadata(request: PageUpsertRequest) -> None:
@@ -51,6 +68,12 @@ def _log_dry_run_metadata(request: PageUpsertRequest) -> None:
             "[DRY-RUN] Would restrict edits on '%s' to accountId=%s",
             request.title,
             request.restrict_edits_to,
+        )
+    if request.page_width is not None:
+        log.debug(
+            "[DRY-RUN] Would set page width on '%s' to '%s'",
+            request.title,
+            request.page_width,
         )
 
 

--- a/sync_confluence/src/sync_confluence/confluence/_types.py
+++ b/sync_confluence/src/sync_confluence/confluence/_types.py
@@ -19,6 +19,7 @@ class PageUpsertRequest:
     restrict_edits_to: Optional[str] = None
     source_path: Optional[str] = None
     source_path_map: Optional[dict[str, str]] = None
+    page_width: Optional[str] = None
 
 
 @dataclass

--- a/sync_confluence/src/sync_confluence/converter.py
+++ b/sync_confluence/src/sync_confluence/converter.py
@@ -47,6 +47,17 @@ _CONFLUENCE_MERMAID_MACRO = (
     "</ac:structured-macro>"
 )
 
+_CONFLUENCE_IMAGE_ATTACHMENT = (
+    '<ac:image><ri:attachment ri:filename="{filename}"/></ac:image>'
+)
+
+# Regex for <img ... src="relative/path"> tags produced by the markdown library
+# for local image references.  Excludes http/https/# URLs.
+_IMG_SRC_RE = re.compile(
+    r'<img([^>]*?)\bsrc="(?!https?://|#)([^"]+)"([^>]*?)>',
+    re.DOTALL,
+)
+
 # ---------------------------------------------------------------------------
 # Page title derivation
 # ---------------------------------------------------------------------------
@@ -59,13 +70,23 @@ def _unescape_code_body(body: str) -> str:
     return html.unescape(body)
 
 
-def _replace_code_block(match: re.Match, mermaid_macro: Optional[str]) -> str:
-    """Replace a fenced code block with a Confluence macro."""
+def _replace_code_block(
+    match: re.Match,
+    mermaid_macro: Optional[str],
+    mermaid_attachments: Optional[dict[str, str]],
+) -> str:
+    """Replace a fenced code block with a Confluence macro or image attachment."""
     language = match.group(1)
     code_body = _unescape_code_body(match.group(2))
 
-    if language == "mermaid" and mermaid_macro:
-        return _CONFLUENCE_MERMAID_MACRO.format(macro=mermaid_macro, code=code_body)
+    if language == "mermaid":
+        att_filename = (
+            mermaid_attachments.get(code_body) if mermaid_attachments else None
+        )  # noqa: WPS221
+        if att_filename is not None:
+            return _CONFLUENCE_IMAGE_ATTACHMENT.format(filename=att_filename)
+        if mermaid_macro:
+            return _CONFLUENCE_MERMAID_MACRO.format(macro=mermaid_macro, code=code_body)
 
     return _CONFLUENCE_CODE_MACRO.format(language=language, code=code_body)
 
@@ -105,27 +126,64 @@ def _rewrite_relative_link(
     return f'<a href="{github_url}">'
 
 
-def convert_markdown(
+def _replace_local_image(
+    match: re.Match,
+    image_attachments: dict[str, str],
+) -> str:
+    """Replace a local <img src="..."> tag with a Confluence attachment image macro."""
+    src = match.group(2)
+    att_filename = image_attachments.get(src)
+    if att_filename is not None:
+        return _CONFLUENCE_IMAGE_ATTACHMENT.format(filename=att_filename)
+    return match.group(0)
+
+
+def convert_markdown(  # noqa: WPS211 — all params are independent optional features
     text: str,
     *,
     mermaid_macro: Optional[str] = None,
+    mermaid_attachments: Optional[dict[str, str]] = None,
+    image_attachments: Optional[dict[str, str]] = None,
     repo_url: Optional[str] = None,
     git_ref: str = "main",
     current_file: Optional[Path] = None,
 ) -> str:
-    """Convert Markdown text to Confluence Storage Format (XHTML)."""
+    """Convert Markdown text to Confluence Storage Format (XHTML).
+
+    Args:
+        text: Raw Markdown source.
+        mermaid_macro: Confluence macro name for Mermaid diagrams (e.g.
+            ``"mermaid-cloud"``).  Ignored when *mermaid_attachments* maps the
+            same source to an attachment filename.
+        mermaid_attachments: Mapping of unescaped mermaid source body to the
+            attachment filename that holds the rendered SVG.  Takes priority
+            over *mermaid_macro* for matched blocks.
+        image_attachments: Mapping of relative image path (as written in the
+            Markdown) to the attachment filename on the Confluence page.
+        repo_url: GitHub repository URL used to rewrite relative ``.md`` links.
+        git_ref: Git ref used when constructing GitHub blob URLs.
+        current_file: Path of the Markdown file being converted; required for
+            relative-link rewriting.
+    """
     converter = md.Markdown(
         extensions=["tables", "fenced_code", "toc", "md_in_html"],
         output_format="html",
     )
     body = converter.convert(text)
 
-    # Post-process: fenced code blocks → Confluence code macros
+    # Post-process: fenced code blocks → Confluence code macros / image attachments
     body = _CODE_BLOCK_RE.sub(
-        lambda match: _replace_code_block(match, mermaid_macro),
+        lambda match: _replace_code_block(match, mermaid_macro, mermaid_attachments),
         body,
     )
     body = _CODE_BLOCK_BARE_RE.sub(_replace_bare_code_block, body)
+
+    # Post-process: local <img src> tags → Confluence attachment image macros
+    if image_attachments:
+        body = _IMG_SRC_RE.sub(
+            lambda match: _replace_local_image(match, image_attachments),
+            body,
+        )
 
     # Post-process: rewrite relative links to GitHub URLs
     if repo_url and current_file:
@@ -139,13 +197,6 @@ def convert_markdown(
     return body
 
 
-def _extract_h1_or_none(md_path: Path) -> Optional[str]:
-    """Return the first H1 heading text from *md_path*, or ``None``."""
-    file_content = md_path.read_text(encoding="utf-8")
-    h1_match = _H1_RE.search(file_content)
-    return h1_match.group(1).strip() if h1_match else None
-
-
 def derive_title(md_path: Path, docs_root: Path, root_title: Optional[str]) -> str:
     """Derive a Confluence page title from a markdown file path.
 
@@ -155,12 +206,11 @@ def derive_title(md_path: Path, docs_root: Path, root_title: Optional[str]) -> s
     - Non-README files: extract the first H1; fall back to title-casing the
       file stem when no H1 is present.
     """
+    h1_match = _H1_RE.search(md_path.read_text(encoding="utf-8"))
+    h1 = h1_match.group(1).strip() if h1_match else None
     is_readme = md_path.name == "README.md"
     if is_readme and md_path.parent == docs_root:
-        return root_title or _extract_h1_or_none(md_path) or "Documentation"
+        return root_title or h1 or "Documentation"
     if is_readme:
-        return (
-            _extract_h1_or_none(md_path)
-            or md_path.parent.name.replace("-", " ").title()
-        )
-    return _extract_h1_or_none(md_path) or md_path.stem.replace("-", " ").title()
+        return h1 or md_path.parent.name.replace("-", " ").title()
+    return h1 or md_path.stem.replace("-", " ").title()

--- a/sync_confluence/src/sync_confluence/traversal/_anchor.py
+++ b/sync_confluence/src/sync_confluence/traversal/_anchor.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Optional
 
-from sync_confluence.confluence import upsert_page
+from sync_confluence.confluence import upsert_attachment, upsert_page
+from sync_confluence.traversal._images import attachment_content_type
 from sync_confluence.traversal._state import log
 from sync_confluence.traversal._sync_state import _maybe_log, _Sync
 
@@ -15,8 +16,19 @@ _ICON_SECTION = "\U0001f4c1"  # 📁
 def _upsert_readme(
     state: _Sync, parent_id: str, readme: Path, title: str
 ) -> tuple[Optional[str], str]:
-    request = state.builder.build_readme_request(parent_id, readme, title)
-    return upsert_page(state.ctx.confluence, request)
+    page_req = state.builder.build_readme_request(parent_id, readme, title)
+    page_id, action = upsert_page(state.ctx.confluence, page_req.request)
+    if action in ("created", "updated") and page_req.attachments:
+        for filename, raw_bytes in page_req.attachments.items():
+            upsert_attachment(
+                state.ctx.confluence,
+                page_id,  # type: ignore[arg-type]  # page_id is str in non-dry-run
+                filename,
+                raw_bytes,
+                attachment_content_type(filename),
+                dry_run=state.ctx.dry_run,
+            )
+    return page_id, action
 
 
 def _anchor_readme(

--- a/sync_confluence/src/sync_confluence/traversal/_builder.py
+++ b/sync_confluence/src/sync_confluence/traversal/_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from sync_confluence.confluence import (
@@ -10,9 +12,29 @@ from sync_confluence.confluence import (
     build_source_path_map,
 )
 from sync_confluence.converter import convert_markdown, derive_title
+from sync_confluence.traversal._diagrams import (
+    extract_mermaid_blocks,
+    mermaid_attachment_filename,
+    render_mermaid_svg,
+)
+from sync_confluence.traversal._images import (
+    SUPPORTED_LOCAL_IMAGE_EXTENSIONS,
+    extract_local_image_paths,
+    local_image_attachment_filename,
+)
 from sync_confluence.traversal._state import SyncContext
 
+log = logging.getLogger(__name__)
+
 _DRY_RUN_ID = "DRY-RUN"
+
+
+@dataclass
+class _AttachedPageRequest:
+    """A page upsert request paired with its attachment payload."""
+
+    request: PageUpsertRequest
+    attachments: dict[str, bytes] = field(default_factory=dict)  # filename → raw bytes
 
 
 def _collect_md_files(directory: Path, readme_as_parent: bool) -> list[Path]:
@@ -24,7 +46,7 @@ def _collect_md_files(directory: Path, readme_as_parent: bool) -> list[Path]:
     return sorted(directory.glob("*.md"))
 
 
-class _RequestBuilder:
+class _RequestBuilder:  # noqa: WPS214 — builder needs init + render + resolve + 4 build methods + private helper
     """Builds page/folder requests from a :class:`SyncContext`.
 
     *allow_root_title* controls whether a ``README.md`` encountered in the
@@ -53,17 +75,35 @@ class _RequestBuilder:
 
     def build_readme_request(
         self, parent_id: str, readme: Path, title: str
-    ) -> PageUpsertRequest:
-        return PageUpsertRequest(
-            space_key=self._ctx.space_key,
-            parent_id=parent_id,
-            title=title,
-            body=self.render(readme),
-            dry_run=self._ctx.dry_run,
-            managed_by_label=self._ctx.managed_by_label,
-            restrict_edits_to=self._ctx.restrict_edits_to,
-            source_path=str(readme.relative_to(self._ctx.docs_root)),
-            page_width=self._ctx.page_width,
+    ) -> _AttachedPageRequest:
+        text = readme.read_text(encoding="utf-8")
+        mermaid_attachments, image_attachments, upload_data = (
+            self._collect_attachments(readme, text)
+            if self._ctx.upload_attachments
+            else ({}, {}, {})
+        )
+        body = convert_markdown(
+            text,
+            mermaid_macro=self._ctx.mermaid_macro,
+            mermaid_attachments=mermaid_attachments or None,
+            image_attachments=image_attachments or None,
+            repo_url=self._ctx.repo_url,
+            git_ref=self._ctx.git_ref,
+            current_file=readme,
+        )
+        return _AttachedPageRequest(
+            request=PageUpsertRequest(
+                space_key=self._ctx.space_key,
+                parent_id=parent_id,
+                title=title,
+                body=body,
+                dry_run=self._ctx.dry_run,
+                managed_by_label=self._ctx.managed_by_label,
+                restrict_edits_to=self._ctx.restrict_edits_to,
+                source_path=str(readme.relative_to(self._ctx.docs_root)),
+                page_width=self._ctx.page_width,
+            ),
+            attachments=upload_data,
         )
 
     def build_page_request(
@@ -72,18 +112,36 @@ class _RequestBuilder:
         md_file: Path,
         title: str,
         source_path_map: dict[str, str],
-    ) -> PageUpsertRequest:
-        return PageUpsertRequest(
-            space_key=self._ctx.space_key,
-            parent_id=parent_id,
-            title=title,
-            body=self.render(md_file),
-            dry_run=self._ctx.dry_run,
-            managed_by_label=self._ctx.managed_by_label,
-            restrict_edits_to=self._ctx.restrict_edits_to,
-            source_path=str(md_file.relative_to(self._ctx.docs_root)),
-            source_path_map=source_path_map,
-            page_width=self._ctx.page_width,
+    ) -> _AttachedPageRequest:
+        text = md_file.read_text(encoding="utf-8")
+        mermaid_attachments, image_attachments, upload_data = (
+            self._collect_attachments(md_file, text)
+            if self._ctx.upload_attachments
+            else ({}, {}, {})
+        )
+        body = convert_markdown(
+            text,
+            mermaid_macro=self._ctx.mermaid_macro,
+            mermaid_attachments=mermaid_attachments or None,
+            image_attachments=image_attachments or None,
+            repo_url=self._ctx.repo_url,
+            git_ref=self._ctx.git_ref,
+            current_file=md_file,
+        )
+        return _AttachedPageRequest(
+            request=PageUpsertRequest(
+                space_key=self._ctx.space_key,
+                parent_id=parent_id,
+                title=title,
+                body=body,
+                dry_run=self._ctx.dry_run,
+                managed_by_label=self._ctx.managed_by_label,
+                restrict_edits_to=self._ctx.restrict_edits_to,
+                source_path=str(md_file.relative_to(self._ctx.docs_root)),
+                source_path_map=source_path_map,
+                page_width=self._ctx.page_width,
+            ),
+            attachments=upload_data,
         )
 
     def build_folder_request(
@@ -102,3 +160,44 @@ class _RequestBuilder:
         if self._ctx.dry_run or page_id == _DRY_RUN_ID:
             return {}
         return build_source_path_map(self._ctx.confluence, page_id)
+
+    def _collect_attachments(  # noqa: WPS210, WPS231 — two parallel loops; complexity is inherent
+        self, md_file: Path, text: str
+    ) -> tuple[dict[str, str], dict[str, str], dict[str, bytes]]:  # noqa: WPS221
+        """Scan *text* for mermaid blocks and local images; render / read them.
+
+        Returns a 3-tuple:
+        - *mermaid_attachments*: ``{unescaped_source: filename}``
+        - *image_attachments*: ``{rel_path: filename}``
+        - *upload_data*: ``{filename: bytes}`` — the payload to upload
+        """
+        mermaid_att: dict[str, str] = {}  # noqa: WPS221
+        image_att: dict[str, str] = {}  # noqa: WPS221
+        upload_data: dict[str, bytes] = {}  # noqa: WPS221
+
+        # --- Mermaid blocks ---
+        if self._ctx.mmdc_path:
+            for source in extract_mermaid_blocks(text):
+                filename = mermaid_attachment_filename(source)
+                svg_bytes = render_mermaid_svg(source, self._ctx.mmdc_path)
+                if svg_bytes is not None:
+                    mermaid_att[source] = filename
+                    upload_data[filename] = svg_bytes
+
+        # --- Local images ---
+        for rel_path in extract_local_image_paths(text):
+            suffix = Path(rel_path).suffix.lower()
+            if suffix not in SUPPORTED_LOCAL_IMAGE_EXTENSIONS:
+                log.debug(
+                    "Skipping unsupported image extension %s: %s", suffix, rel_path
+                )
+                continue
+            abs_path = md_file.parent / rel_path
+            if not abs_path.is_file():
+                log.warning("Local image not found, skipping: %s", abs_path)
+                continue
+            filename = local_image_attachment_filename(rel_path)
+            image_att[rel_path] = filename
+            upload_data[filename] = abs_path.read_bytes()
+
+        return mermaid_att, image_att, upload_data

--- a/sync_confluence/src/sync_confluence/traversal/_builder.py
+++ b/sync_confluence/src/sync_confluence/traversal/_builder.py
@@ -63,6 +63,7 @@ class _RequestBuilder:
             managed_by_label=self._ctx.managed_by_label,
             restrict_edits_to=self._ctx.restrict_edits_to,
             source_path=str(readme.relative_to(self._ctx.docs_root)),
+            page_width=self._ctx.page_width,
         )
 
     def build_page_request(
@@ -82,6 +83,7 @@ class _RequestBuilder:
             restrict_edits_to=self._ctx.restrict_edits_to,
             source_path=str(md_file.relative_to(self._ctx.docs_root)),
             source_path_map=source_path_map,
+            page_width=self._ctx.page_width,
         )
 
     def build_folder_request(

--- a/sync_confluence/src/sync_confluence/traversal/_diagrams.py
+++ b/sync_confluence/src/sync_confluence/traversal/_diagrams.py
@@ -1,0 +1,121 @@
+"""Mermaid diagram extraction and SVG rendering via the mmdc CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Regex to extract the body of ```mermaid ... ``` blocks from raw Markdown.
+_MERMAID_BLOCK_RE = re.compile(
+    r"^```mermaid\s*\n(.*?)^```",
+    re.MULTILINE | re.DOTALL,
+)
+
+_HASH_PREFIX_LEN = 12  # first N hex chars of sha256 used as the diagram filename
+_MMDC_TIMEOUT = 30  # seconds per diagram render
+
+
+def extract_mermaid_blocks(text: str) -> list[str]:
+    """Return a list of mermaid source bodies found in raw Markdown text.
+
+    Each entry is the raw text between the opening mermaid code fence
+    and the closing fence.
+    """
+    return [blk.group(1) for blk in _MERMAID_BLOCK_RE.finditer(text)]
+
+
+def mermaid_attachment_filename(source: str) -> str:
+    """Return a stable, collision-resistant attachment filename for *source*.
+
+    Format: ``mermaid-<first-12-hex-chars-of-sha256>.svg``
+    """
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    short_hash = digest[:_HASH_PREFIX_LEN]
+    return f"mermaid-{short_hash}.svg"
+
+
+def render_mermaid_svg(source: str, mmdc_path: str) -> Optional[bytes]:
+    """Render a Mermaid *source* string to SVG bytes using the mmdc CLI.
+
+    Returns ``None`` and logs a warning on any error (non-zero exit, binary
+    not found, or timeout).
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        in_path = Path(tmp_dir) / "diagram.mmd"
+        out_path = Path(tmp_dir) / "diagram.svg"
+        in_path.write_text(source, encoding="utf-8")
+
+        try:
+            proc = subprocess.run(
+                [
+                    mmdc_path,
+                    "-i",
+                    str(in_path),
+                    "-o",
+                    str(out_path),
+                    "--outputFormat",
+                    "svg",
+                ],
+                capture_output=True,
+                timeout=_MMDC_TIMEOUT,
+            )
+        except FileNotFoundError:
+            log.warning("mmdc not found at %s — skipping mermaid render", mmdc_path)
+            return None
+        except subprocess.TimeoutExpired:
+            log.warning(
+                "mmdc timed out after %ds rendering a diagram — skipping", _MMDC_TIMEOUT
+            )
+            return None
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+            log.warning(
+                "mmdc exited with code %d — skipping mermaid render. stderr: %s",
+                proc.returncode,
+                stderr,
+            )
+            return None
+
+        return out_path.read_bytes()
+
+
+def find_mmdc(mmdc_path_override: Optional[str]) -> Optional[str]:
+    """Resolve the path to the mmdc binary.
+
+    If *mmdc_path_override* is provided, verify it is executable and return
+    it; log a warning and return ``None`` if it cannot be found.  When no
+    override is set, fall back to ``shutil.which("mmdc")``.
+
+    This function is intended to be called **once** at startup so that the
+    single warning fires before the sync walk begins.
+    """
+    if mmdc_path_override:
+        candidate = Path(mmdc_path_override)
+        if candidate.is_file() and shutil.os.access(candidate, shutil.os.X_OK):  # type: ignore[attr-defined]
+            return str(candidate)
+        resolved_override = shutil.which(mmdc_path_override)
+        if resolved_override:
+            return resolved_override
+        log.warning(
+            "mmdc binary not found at %s — mermaid diagrams will not be rendered",
+            mmdc_path_override,
+        )
+        return None
+
+    resolved = shutil.which("mmdc")
+    if resolved:
+        return resolved
+    log.warning(
+        "mmdc not found on PATH — mermaid diagrams will not be rendered. "
+        "Install with: npm install -g @mermaid-js/mermaid-cli"
+    )
+    return None

--- a/sync_confluence/src/sync_confluence/traversal/_images.py
+++ b/sync_confluence/src/sync_confluence/traversal/_images.py
@@ -1,0 +1,64 @@
+"""Local image reference extraction and attachment filename helpers."""
+
+from __future__ import annotations
+
+import re
+from types import MappingProxyType
+from typing import Mapping
+
+# Regex to find ![alt](path) references in raw Markdown.
+_LOCAL_IMAGE_RE = re.compile(r"!\[.*?\]\(([^)]+)\)")
+
+# Content-type registry for all attachment types used by sync_confluence.
+# SVG is produced by mermaid rendering only; it is not a valid local image
+# upload extension (see SUPPORTED_LOCAL_IMAGE_EXTENSIONS below).
+CONTENT_TYPES: Mapping[str, str] = MappingProxyType(
+    {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".svg": "image/svg+xml",
+    }
+)
+
+# Subset of extensions eligible for local image uploads.
+SUPPORTED_LOCAL_IMAGE_EXTENSIONS: frozenset[str] = frozenset((".png", ".jpg", ".jpeg"))
+
+
+def extract_local_image_paths(text: str) -> list[str]:
+    """Return relative image paths found in raw Markdown *text*.
+
+    External URLs (``http://``, ``https://``, ``#``, or any path containing
+    ``://``) are excluded.
+    """
+    paths: list[str] = []
+    for match in _LOCAL_IMAGE_RE.finditer(text):
+        path = match.group(1).strip()
+        if path.startswith(("http://", "https://", "#")) or "://" in path:
+            continue
+        paths.append(path)
+    return paths
+
+
+def local_image_attachment_filename(rel_path: str) -> str:
+    """Convert a relative image path to a safe Confluence attachment filename.
+
+    Strips a leading ``./``, then replaces ``/`` and backslash with ``-``.
+
+    Examples::
+
+        "images/logo.png"   to   "images-logo.png"
+        "./assets/fig.jpg"  to   "assets-fig.jpg"
+    """
+    path = rel_path.lstrip("./") if rel_path.startswith("./") else rel_path
+    return path.replace("/", "-").replace("\\", "-")
+
+
+def attachment_content_type(filename: str) -> str:
+    """Return the MIME content-type for *filename* based on its extension.
+
+    Falls back to ``"application/octet-stream"`` for unknown extensions.
+    """
+    suffix = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""  # noqa: WPS221
+    ext_key = f".{suffix}"
+    return CONTENT_TYPES.get(ext_key, "application/octet-stream")  # noqa: WPS221

--- a/sync_confluence/src/sync_confluence/traversal/_md_files.py
+++ b/sync_confluence/src/sync_confluence/traversal/_md_files.py
@@ -4,11 +4,26 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from sync_confluence.confluence import upsert_page
-from sync_confluence.traversal._builder import _collect_md_files
+from sync_confluence.confluence import upsert_attachment, upsert_page
+from sync_confluence.traversal._builder import _AttachedPageRequest, _collect_md_files
+from sync_confluence.traversal._images import attachment_content_type
 from sync_confluence.traversal._sync_state import _maybe_log, _Sync
 
 _ICON_FILE = "\U0001f4c4"  # 📄
+
+
+def _upload_attachments(
+    state: _Sync, page_id: str, page_req: _AttachedPageRequest
+) -> None:
+    for filename, raw_bytes in page_req.attachments.items():
+        upsert_attachment(
+            state.ctx.confluence,
+            page_id,
+            filename,
+            raw_bytes,
+            attachment_content_type(filename),
+            dry_run=state.ctx.dry_run,
+        )
 
 
 def _sync_one_md_file(
@@ -19,12 +34,14 @@ def _sync_one_md_file(
     depth: int,
 ) -> None:
     title = state.builder.resolve_md_title(md_file)
-    request = state.builder.build_page_request(
+    page_req = state.builder.build_page_request(
         parent_id, md_file, title, source_path_map
     )
-    page_id, action = upsert_page(state.ctx.confluence, request)
+    page_id, action = upsert_page(state.ctx.confluence, page_req.request)
     _maybe_log(state.ctx.dry_run, depth, _ICON_FILE, title)
     state.recorder.record_page(md_file, title, page_id, action)
+    if action in ("created", "updated") and page_req.attachments:
+        _upload_attachments(state, page_id, page_req)
 
 
 def _sync_md_files(

--- a/sync_confluence/src/sync_confluence/traversal/_state.py
+++ b/sync_confluence/src/sync_confluence/traversal/_state.py
@@ -39,6 +39,10 @@ class SyncContext:
     managed_by_label: Optional[str] = None
     restrict_edits_to: Optional[str] = None
     page_width: Optional[str] = None
+    upload_attachments: bool = False
+    mmdc_path: Optional[str] = (
+        None  # resolved path to mmdc binary; None disables mermaid rendering
+    )
 
 
 def _new_sync_result() -> SyncResult:

--- a/sync_confluence/src/sync_confluence/traversal/_state.py
+++ b/sync_confluence/src/sync_confluence/traversal/_state.py
@@ -38,6 +38,7 @@ class SyncContext:
     dry_run: bool = False
     managed_by_label: Optional[str] = None
     restrict_edits_to: Optional[str] = None
+    page_width: Optional[str] = None
 
 
 def _new_sync_result() -> SyncResult:

--- a/sync_confluence/tests/test_attachment.py
+++ b/sync_confluence/tests/test_attachment.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from sync_confluence.confluence._attachment import upsert_attachment
+
+_PAGE_ID = "page-1"
+
+
+class TestUpsertAttachment:
+    """Tests for upsert_attachment()."""
+
+    def test_dry_run_returns_dry_run_id(self):
+        confluence = MagicMock()
+        att_id = upsert_attachment(
+            confluence, "123", "logo.png", b"data", "image/png", dry_run=True
+        )
+        assert att_id == "DRY-RUN"
+        confluence.get_attachments_from_content.assert_not_called()
+        confluence.attach_content.assert_not_called()
+
+    def test_creates_when_no_existing_attachment(self):
+        confluence = MagicMock()
+        confluence.get_attachments_from_content.return_value = {"results": []}
+        confluence.attach_content.return_value = {"results": [{"id": "att-99"}]}
+
+        att_id = upsert_attachment(
+            confluence,
+            _PAGE_ID,
+            "diagram.svg",
+            b"<svg/>",
+            "image/svg+xml",
+            dry_run=False,
+        )
+
+        assert att_id == "att-99"
+        confluence.get_attachments_from_content.assert_called_once_with(
+            _PAGE_ID, filename="diagram.svg", limit=1
+        )
+        confluence.attach_content.assert_called_once_with(
+            content=b"<svg/>",
+            name="diagram.svg",
+            content_type="image/svg+xml",
+            page_id=_PAGE_ID,
+        )
+        confluence.update_attachment.assert_not_called()
+
+    def test_updates_when_attachment_already_exists(self):
+        confluence = MagicMock()
+        confluence.get_attachments_from_content.return_value = {
+            "results": [{"id": "att-42"}]
+        }
+
+        att_id = upsert_attachment(
+            confluence, _PAGE_ID, "logo.png", b"bytes", "image/png", dry_run=False
+        )
+
+        assert att_id == "att-42"
+        confluence.attach_content.assert_not_called()
+        confluence.update_attachment.assert_called_once_with(
+            page_id=_PAGE_ID,
+            attachment_id="att-42",
+            content=b"bytes",
+            name="logo.png",
+            content_type="image/png",
+        )

--- a/sync_confluence/tests/test_cli.py
+++ b/sync_confluence/tests/test_cli.py
@@ -6,6 +6,8 @@ import pytest
 
 from sync_confluence.cli import parse_args, validate_args
 
+_FULL_WIDTH = "full-width"
+
 
 class TestParseArgs:
     """Tests for parse_args()."""
@@ -52,6 +54,32 @@ class TestParseArgs:
         assert args.no_root is True
 
 
+class TestParseArgsPageWidth:
+    """Tests for --page-width / CONFLUENCE_PAGE_WIDTH in parse_args()."""
+
+    def test_page_width_defaults_to_none(self, monkeypatch):
+        monkeypatch.delenv("CONFLUENCE_PAGE_WIDTH", raising=False)
+        args = parse_args([])
+        assert args.page_width is None
+
+    def test_page_width_flag(self):
+        args = parse_args(["--page-width", _FULL_WIDTH])
+        assert args.page_width == _FULL_WIDTH
+
+    def test_page_width_default_flag(self):
+        args = parse_args(["--page-width", "default"])
+        assert args.page_width == "default"
+
+    def test_page_width_env_var(self, monkeypatch):
+        monkeypatch.setenv("CONFLUENCE_PAGE_WIDTH", _FULL_WIDTH)
+        args = parse_args([])
+        assert args.page_width == _FULL_WIDTH
+
+    def test_page_width_invalid_flag_rejected(self):
+        with pytest.raises(SystemExit):
+            parse_args(["--page-width", "wide"])
+
+
 class TestValidateArgs:
     """Tests for validate_args()."""
 
@@ -84,18 +112,41 @@ class TestValidateArgs:
             validate_args(args)
         assert exc_info.value.code == 2
 
+    def _make_args(self, **overrides: object) -> argparse.Namespace:
+        return _make_args(**overrides)
+
+
+class TestValidateArgsPageWidth:
+    """Tests for page_width validation in validate_args()."""
+
+    def test_invalid_page_width_env_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            validate_args(_make_args(page_width="wide"))
+        assert exc_info.value.code == 2
+
+    def test_valid_page_width_passes(self):
+        validate_args(_make_args(page_width=_FULL_WIDTH))
+
+    def test_none_page_width_passes(self):
+        validate_args(_make_args(page_width=None))
+
     def _make_args(self, **overrides):
-        defaults = {
-            "url": "https://acme.atlassian.net",
-            "email": "user@acme.com",
-            "token": "secret",
-            "space": "DOCS",
-            "parent_id": "12345",
-            "no_root": False,
-            "root_parent": None,
-            "root_title": None,
-            "docs_dir": None,
-            "docs_files": None,
-        }
-        defaults.update(overrides)
-        return argparse.Namespace(**defaults)
+        return _make_args(**overrides)
+
+
+def _make_args(**overrides: object) -> argparse.Namespace:
+    defaults = {
+        "url": "https://acme.atlassian.net",
+        "email": "user@acme.com",
+        "token": "secret",
+        "space": "DOCS",
+        "parent_id": "12345",
+        "no_root": False,
+        "root_parent": None,
+        "root_title": None,
+        "docs_dir": None,
+        "docs_files": None,
+        "page_width": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)

--- a/sync_confluence/tests/test_converter.py
+++ b/sync_confluence/tests/test_converter.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from sync_confluence.converter import convert_markdown, derive_title
 
 README_FILENAME = "README.md"
+_MERMAID_MACRO = "mermaid-cloud"
 
 
 class TestConvertMarkdown:
-    """Tests for convert_markdown()."""
+    """Tests for convert_markdown() — core rendering."""
 
     def test_plain_paragraph(self):
         output = convert_markdown("Hello world")
@@ -34,8 +35,8 @@ class TestConvertMarkdown:
 
     def test_mermaid_block_with_macro(self):
         md = "```mermaid\ngraph TD;\n```"
-        output = convert_markdown(md, mermaid_macro="mermaid-cloud")
-        assert 'ac:name="mermaid-cloud"' in output
+        output = convert_markdown(md, mermaid_macro=_MERMAID_MACRO)
+        assert f'ac:name="{_MERMAID_MACRO}"' in output
         assert "graph TD;" in output
 
     def test_table_rendering(self):
@@ -50,6 +51,64 @@ class TestConvertMarkdown:
         # CDATA should contain raw < and >, not &lt; &gt;
         assert "x < 10" in output
         assert "y > 5" in output
+
+
+class TestConvertMarkdownMermaidAttachments:
+    """Tests for convert_markdown() — mermaid attachment handling."""
+
+    def test_attachment_replaces_code_block(self):
+        source = "flowchart LR\n  A --> B\n"
+        md = f"```mermaid\n{source}```"
+        output = convert_markdown(md, mermaid_attachments={source: "mermaid-abc.svg"})
+        assert 'ri:filename="mermaid-abc.svg"' in output
+        assert "ac:structured-macro" not in output
+
+    def test_attachment_beats_macro(self):
+        source = "graph TD;\n"
+        md = f"```mermaid\n{source}```"
+        output = convert_markdown(
+            md,
+            mermaid_macro=_MERMAID_MACRO,
+            mermaid_attachments={source: "mermaid-xyz.svg"},
+        )
+        assert 'ri:filename="mermaid-xyz.svg"' in output
+        assert _MERMAID_MACRO not in output
+
+    def test_falls_to_macro_when_not_in_map(self):
+        source = "graph TD;\n"
+        md = f"```mermaid\n{source}```"
+        # attachment map does not contain this source
+        output = convert_markdown(
+            md,
+            mermaid_macro=_MERMAID_MACRO,
+            mermaid_attachments={"other source\n": "other.svg"},
+        )
+        assert f'ac:name="{_MERMAID_MACRO}"' in output
+
+
+class TestConvertMarkdownImageAttachments:
+    """Tests for convert_markdown() — local image attachment handling."""
+
+    def test_local_image_replaced_in_map(self):
+        md = "Here is ![arch](images/arch.png) diagram."
+        output = convert_markdown(
+            md, image_attachments={"images/arch.png": "images-arch.png"}
+        )
+        assert 'ri:filename="images-arch.png"' in output
+        assert "<img" not in output
+
+    def test_local_image_passthrough_when_not_in_map(self):
+        md = "Here is ![arch](images/arch.png) diagram."
+        output = convert_markdown(md, image_attachments={"other.png": "other.png"})
+        # src not in map — original img tag or link preserved
+        assert 'ri:filename="images-arch.png"' not in output
+
+    def test_external_image_not_replaced(self):
+        md = "![remote](https://example.com/img.png)"
+        output = convert_markdown(
+            md, image_attachments={"https://example.com/img.png": "should-not.png"}
+        )
+        assert 'ri:filename="should-not.png"' not in output
 
 
 class TestDeriveTitle:

--- a/sync_confluence/tests/test_diagrams.py
+++ b/sync_confluence/tests/test_diagrams.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sync_confluence.traversal._diagrams import (
+    extract_mermaid_blocks,
+    find_mmdc,
+    mermaid_attachment_filename,
+    render_mermaid_svg,
+)
+
+_SUBPROCESS_PATCH = "sync_confluence.traversal._diagrams.subprocess.run"
+_WHICH_PATCH = "sync_confluence.traversal._diagrams.shutil.which"
+_MMDC_BIN = "/usr/local/bin/mmdc"
+_FILE_PERMS = 0o755
+_TIMEOUT_SECS = 30
+
+_SVG_BYTES = b"<svg>diagram</svg>"
+
+
+def _fake_mmdc_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+    """Fake subprocess.run that writes _SVG_BYTES to the -o output path."""
+    out_idx = cmd.index("-o") + 1
+    Path(cmd[out_idx]).write_bytes(_SVG_BYTES)
+    proc = MagicMock()
+    proc.returncode = 0
+    return proc
+
+
+class TestExtractMermaidBlocks:
+    """Tests for extract_mermaid_blocks()."""
+
+    def test_single_block(self):
+        text = "Intro\n\n```mermaid\nflowchart LR\n  A --> B\n```\n\nEnd"
+        blocks = extract_mermaid_blocks(text)
+        assert blocks == ["flowchart LR\n  A --> B\n"]
+
+    def test_multiple_blocks(self):
+        text = "```mermaid\ngraph TD;\n```\n\n```mermaid\nsequenceDiagram\n```\n"
+        blocks = extract_mermaid_blocks(text)
+        assert len(blocks) == 2
+        assert "graph TD;\n" in blocks
+        assert "sequenceDiagram\n" in blocks
+
+    def test_no_blocks(self):
+        text = "Just some text\n\n```python\nprint('hi')\n```\n"
+        assert extract_mermaid_blocks(text) == []
+
+    def test_non_mermaid_fence_not_matched(self):
+        text = "```plantuml\n@startuml\n@enduml\n```\n"
+        assert extract_mermaid_blocks(text) == []
+
+
+class TestMermaidAttachmentFilename:
+    """Tests for mermaid_attachment_filename()."""
+
+    def test_returns_svg_extension(self):
+        filename = mermaid_attachment_filename("flowchart LR\n  A --> B\n")
+        assert filename.endswith(".svg")
+        assert filename.startswith("mermaid-")
+
+    def test_stable_for_same_source(self):
+        source = "graph TD;\n  A --> B;\n"
+        assert mermaid_attachment_filename(source) == mermaid_attachment_filename(
+            source
+        )
+
+    def test_differs_for_different_sources(self):
+        assert mermaid_attachment_filename("A --> B") != mermaid_attachment_filename(
+            "B --> A"
+        )
+
+    def test_filename_length(self):
+        # "mermaid-" (8) + 12 hex chars + ".svg" (4) = 24
+        filename = mermaid_attachment_filename("x")
+        assert len(filename) == 24
+
+
+class TestRenderMermaidSvg:
+    """Tests for render_mermaid_svg()."""
+
+    def test_returns_svg_bytes_on_success(self):
+        with patch(_SUBPROCESS_PATCH, side_effect=_fake_mmdc_run):
+            svg = render_mermaid_svg("flowchart LR\n  A-->B\n", "/usr/bin/mmdc")
+        assert svg == _SVG_BYTES
+
+    def test_returns_none_on_nonzero_exit(self):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stderr = b"Error: parse error"
+        with patch(_SUBPROCESS_PATCH, return_value=proc):
+            svg = render_mermaid_svg("bad diagram", "/usr/bin/mmdc")
+        assert svg is None
+
+    def test_returns_none_when_binary_not_found(self):
+        with patch(_SUBPROCESS_PATCH, side_effect=FileNotFoundError):
+            svg = render_mermaid_svg("graph TD;", "/no/such/mmdc")
+        assert svg is None
+
+    def test_returns_none_on_timeout(self):
+        exc = subprocess.TimeoutExpired(cmd="mmdc", timeout=_TIMEOUT_SECS)
+        with patch(_SUBPROCESS_PATCH, side_effect=exc):
+            svg = render_mermaid_svg("graph TD;", "/usr/bin/mmdc")
+        assert svg is None
+
+
+class TestFindMmdc:
+    """Tests for find_mmdc()."""
+
+    def test_uses_override_when_executable(self, tmp_path):
+        fake_mmdc = tmp_path / "mmdc"
+        fake_mmdc.write_text("#!/bin/sh\necho hi")
+        fake_mmdc.chmod(_FILE_PERMS)
+        found = find_mmdc(str(fake_mmdc))
+        assert found == str(fake_mmdc)
+
+    def test_falls_back_when_override_not_found(self):
+        with patch(_WHICH_PATCH, return_value=_MMDC_BIN):
+            found = find_mmdc("/nonexistent/mmdc")
+        assert found == _MMDC_BIN
+
+    def test_detects_mmdc_on_path_when_no_override(self):
+        with patch(_WHICH_PATCH, return_value=_MMDC_BIN):
+            found = find_mmdc(None)
+        assert found == _MMDC_BIN
+
+    def test_returns_none_when_not_found_anywhere(self):
+        with patch(_WHICH_PATCH, return_value=None):
+            found = find_mmdc(None)
+        assert found is None
+
+    def test_none_when_override_missing_no_path(self):
+        with patch(_WHICH_PATCH, return_value=None):
+            found = find_mmdc("/no/such/binary")
+        assert found is None

--- a/sync_confluence/tests/test_images.py
+++ b/sync_confluence/tests/test_images.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from sync_confluence.traversal._images import (
+    SUPPORTED_LOCAL_IMAGE_EXTENSIONS,
+    attachment_content_type,
+    extract_local_image_paths,
+    local_image_attachment_filename,
+)
+
+
+class TestExtractLocalImagePaths:
+    """Tests for extract_local_image_paths()."""
+
+    def test_basic_relative_path(self):
+        text = "See ![diagram](images/arch.png) for details."
+        assert extract_local_image_paths(text) == ["images/arch.png"]
+
+    def test_dotslash_prefix(self):
+        text = "![logo](./assets/logo.png)"
+        assert extract_local_image_paths(text) == ["./assets/logo.png"]
+
+    def test_skips_http_url(self):
+        text = "![remote](http://example.com/img.png)"
+        assert extract_local_image_paths(text) == []
+
+    def test_skips_https_url(self):
+        text = "![remote](https://example.com/img.png)"
+        assert extract_local_image_paths(text) == []
+
+    def test_skips_anchor(self):
+        text = "![anchor](#section)"
+        assert extract_local_image_paths(text) == []
+
+    def test_multiple_images(self):
+        text = "![a](a.png) and ![b](b.jpg) and ![ext](https://x.com/c.png)"
+        paths = extract_local_image_paths(text)
+        assert paths == ["a.png", "b.jpg"]
+
+    def test_no_images(self):
+        assert extract_local_image_paths("No images here.") == []
+
+
+class TestLocalImageAttachmentFilename:
+    """Tests for local_image_attachment_filename()."""
+
+    def test_nested_path(self):
+        assert local_image_attachment_filename("images/logo.png") == "images-logo.png"
+
+    def test_strips_dotslash(self):
+        assert local_image_attachment_filename("./assets/fig.jpg") == "assets-fig.jpg"
+
+    def test_flat_filename(self):
+        assert local_image_attachment_filename("diagram.png") == "diagram.png"
+
+    def test_deep_nested(self):
+        assert local_image_attachment_filename("a/b/c.png") == "a-b-c.png"
+
+
+class TestAttachmentContentType:
+    """Tests for attachment_content_type()."""
+
+    def test_png(self):
+        assert attachment_content_type("logo.png") == "image/png"
+
+    def test_jpg(self):
+        assert attachment_content_type("photo.jpg") == "image/jpeg"
+
+    def test_jpeg(self):
+        assert attachment_content_type("photo.jpeg") == "image/jpeg"
+
+    def test_svg(self):
+        assert attachment_content_type("mermaid-abc123.svg") == "image/svg+xml"
+
+    def test_unknown_extension_falls_back(self):
+        assert attachment_content_type("file.bin") == "application/octet-stream"
+
+    def test_uppercase_extension(self):
+        assert attachment_content_type("IMAGE.PNG") == "image/png"
+
+
+class TestSupportedLocalImageExtensions:
+    def test_svg_not_in_supported_local(self):
+        assert ".svg" not in SUPPORTED_LOCAL_IMAGE_EXTENSIONS
+
+    def test_png_and_jpeg_in_supported_local(self):
+        assert ".png" in SUPPORTED_LOCAL_IMAGE_EXTENSIONS
+        assert ".jpg" in SUPPORTED_LOCAL_IMAGE_EXTENSIONS
+        assert ".jpeg" in SUPPORTED_LOCAL_IMAGE_EXTENSIONS


### PR DESCRIPTION
This pull request adds support for uploading local images and rendered Mermaid diagrams as Confluence page attachments, enhancing the documentation sync process. It introduces new CLI flags, updates the Markdown-to-Confluence conversion logic to handle attachments, and implements the necessary attachment upload logic. Several internal APIs and builder classes are also extended to support these new features.

**New features:**

* **Attachment upload support:**
  - Added `--upload-attachments` and `--mmdc-path` CLI flags to control uploading of local PNG/JPEG images and Mermaid diagram renders as Confluence attachments. [[1]](diffhunk://#diff-5f64028444f5401dcb42334f614be17713b82e5df352d69cecc0dd7c50f6507bR116-R154) [[2]](diffhunk://#diff-2cc6c407321dfaab7d4dfa58ec18d8f52f3862b7a93357a50b0cac0fbfc2f55aR87-R105)
  - Updated the README with detailed documentation on attachment upload behavior, limitations, and Mermaid CLI installation.

**Markdown conversion and attachment handling:**

* **Markdown converter enhancements:**
  - Modified `convert_markdown` and related functions to replace fenced Mermaid code blocks and local image references with Confluence `<ac:image>` macros referencing uploaded attachments, when present. [[1]](diffhunk://#diff-dc2892a261cd5bb596a25d0edb9d3b9d77334ad30aaf0f095170305c17567e8eR50-R60) [[2]](diffhunk://#diff-dc2892a261cd5bb596a25d0edb9d3b9d77334ad30aaf0f095170305c17567e8eL62-R88) [[3]](diffhunk://#diff-dc2892a261cd5bb596a25d0edb9d3b9d77334ad30aaf0f095170305c17567e8eL108-R187)
  - Added logic to extract and map local image paths and Mermaid blocks to attachment filenames. [[1]](diffhunk://#diff-cda9ad2e9cec49ef2c728f909bc2d0b90a2c2cc4e923ff0cab3f48888fa48ef2R15-R39) [[2]](diffhunk://#diff-cda9ad2e9cec49ef2c728f909bc2d0b90a2c2cc4e923ff0cab3f48888fa48ef2L56-R106)

**Attachment upload implementation:**

* **Confluence API integration:**
  - Implemented `upsert_attachment` to create or update attachments on Confluence pages, including dry-run support. [[1]](diffhunk://#diff-58bd0e8d785420b8ca58f347e5eab2a80633c91d54dda43719379beb64f1a815R1-R96) [[2]](diffhunk://#diff-3a1e914524a77421d5991e1d71600fefe7ac0638e386a0a096725ffa3595a044R13) [[3]](diffhunk://#diff-3a1e914524a77421d5991e1d71600fefe7ac0638e386a0a096725ffa3595a044R30)
  - Integrated attachment upload into the page upsert flow; attachments are uploaded after the page is created or updated. [[1]](diffhunk://#diff-4de5569fe0d88b34a31e753fad109e17b289889c53aaa6d21e982ae8f9603f2eL8-R9) [[2]](diffhunk://#diff-4de5569fe0d88b34a31e753fad109e17b289889c53aaa6d21e982ae8f9603f2eL18-R31)

**Sync context and builder updates:**

* **Sync context propagation:**
  - Extended sync context and builder logic to propagate attachment upload settings and manage attachment data throughout the sync process. [[1]](diffhunk://#diff-8138e450d1db1aacd89f0fd1a6e6bf4b25c2a197ed58685c245823d10d92c87bR17-R26) [[2]](diffhunk://#diff-8138e450d1db1aacd89f0fd1a6e6bf4b25c2a197ed58685c245823d10d92c87bR39-R40) [[3]](diffhunk://#diff-cda9ad2e9cec49ef2c728f909bc2d0b90a2c2cc4e923ff0cab3f48888fa48ef2L27-R49) [[4]](diffhunk://#diff-cda9ad2e9cec49ef2c728f909bc2d0b90a2c2cc4e923ff0cab3f48888fa48ef2L56-R106)

**Other improvements:**

* **Title extraction simplification:**
  - Inlined H1 extraction logic for page title derivation, removing a helper function. [[1]](diffhunk://#diff-dc2892a261cd5bb596a25d0edb9d3b9d77334ad30aaf0f095170305c17567e8eL142-L148) [[2]](diffhunk://#diff-dc2892a261cd5bb596a25d0edb9d3b9d77334ad30aaf0f095170305c17567e8eR209-R216)