### PR TITLE
HAAS-000 Update page width handling to store as JSON object and add tests

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -15,9 +15,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Fetch base branch for diff
-        run: git fetch origin ${{ github.base_ref }} --depth=1
+      - name: Compute changed files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+          all_files=$(echo "$changed" | tr '\n' ' ')
+          echo "all=${all_files}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -25,6 +34,7 @@ jobs:
           python-version: "3.12"
 
       - name: Run pre-commit hooks
+        if: steps.changed.outputs.all != ''
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          extra_args: --files ${{ steps.changed.outputs.all }}

--- a/sync_confluence/src/sync_confluence/confluence/_page_metadata.py
+++ b/sync_confluence/src/sync_confluence/confluence/_page_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
 from atlassian import Confluence
@@ -39,18 +40,19 @@ def _apply_page_metadata(
     if request.restrict_edits_to:
         _apply_edit_restriction(confluence, page_id, request.restrict_edits_to)
     if request.page_width is not None:
+        appearance_value = json.dumps({"layout": request.page_width})
         _try_property_set(
             confluence,
             page_id,
             _APPEARANCE_PUBLISHED_KEY,
-            request.page_width,
+            appearance_value,
             "appearance",
         )
         _try_property_set(
             confluence,
             page_id,
             _APPEARANCE_DRAFT_KEY,
-            request.page_width,
+            appearance_value,
             "appearance",
         )
 

--- a/sync_confluence/tests/test_page_metadata.py
+++ b/sync_confluence/tests/test_page_metadata.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from sync_confluence.confluence._constants import (
+    _APPEARANCE_DRAFT_KEY,
+    _APPEARANCE_PUBLISHED_KEY,
+)
+from sync_confluence.confluence._page_metadata import _apply_page_metadata
+from sync_confluence.confluence._types import PageUpsertRequest
+
+_PATCH_PATH = "sync_confluence.confluence._page_metadata._try_property_set"
+_PAGE_ID = "42"
+_BODY_HASH = "abc123"
+_FULL_WIDTH = "full-width"
+_DEFAULT_WIDTH = "default"
+_APPEARANCE_KEYS = frozenset((_APPEARANCE_PUBLISHED_KEY, _APPEARANCE_DRAFT_KEY))
+
+
+def _make_request(**overrides: object) -> PageUpsertRequest:
+    defaults: dict[str, object] = {
+        "space_key": "DOCS",
+        "parent_id": "1",
+        "title": "Test Page",
+        "body": "<p>body</p>",
+    }
+    defaults.update(overrides)
+    return PageUpsertRequest(**defaults)  # type: ignore[arg-type]
+
+
+def _appearance_values(mock_set: MagicMock) -> list[str]:
+    return [
+        called.args[3]
+        for called in mock_set.call_args_list
+        if called.args[2] in _APPEARANCE_KEYS
+    ]
+
+
+class TestApplyPageMetadataAppearance:
+    """Tests for appearance property serialization in _apply_page_metadata()."""
+
+    @patch(_PATCH_PATH)
+    def test_full_width_stores_json_object(self, mock_set: MagicMock) -> None:
+        confluence = MagicMock()
+        request = _make_request(page_width=_FULL_WIDTH)
+        _apply_page_metadata(confluence, _PAGE_ID, request, _BODY_HASH)
+        raw_values = _appearance_values(mock_set)
+        assert len(raw_values) == 2
+        assert all(json.loads(raw) == {"layout": _FULL_WIDTH} for raw in raw_values)
+
+    @patch(_PATCH_PATH)
+    def test_default_width_stores_json_object(self, mock_set: MagicMock) -> None:
+        confluence = MagicMock()
+        request = _make_request(page_width=_DEFAULT_WIDTH)
+        _apply_page_metadata(confluence, _PAGE_ID, request, _BODY_HASH)
+        raw_values = _appearance_values(mock_set)
+        assert len(raw_values) == 2
+        assert all(json.loads(raw) == {"layout": _DEFAULT_WIDTH} for raw in raw_values)
+
+    @patch(_PATCH_PATH)
+    def test_both_published_and_draft_keys_set(self, mock_set: MagicMock) -> None:
+        confluence = MagicMock()
+        request = _make_request(page_width=_FULL_WIDTH)
+        _apply_page_metadata(confluence, _PAGE_ID, request, _BODY_HASH)
+        keys_set = {called.args[2] for called in mock_set.call_args_list}
+        assert _APPEARANCE_PUBLISHED_KEY in keys_set
+        assert _APPEARANCE_DRAFT_KEY in keys_set
+
+    @patch(_PATCH_PATH)
+    def test_none_page_width_omits_appearance(self, mock_set: MagicMock) -> None:
+        confluence = MagicMock()
+        request = _make_request(page_width=None)
+        _apply_page_metadata(confluence, _PAGE_ID, request, _BODY_HASH)
+        assert _appearance_values(mock_set) == []
+
+    @patch(_PATCH_PATH)
+    def test_value_is_not_plain_string(self, mock_set: MagicMock) -> None:
+        confluence = MagicMock()
+        request = _make_request(page_width=_FULL_WIDTH)
+        _apply_page_metadata(confluence, _PAGE_ID, request, _BODY_HASH)
+        for raw in _appearance_values(mock_set):
+            assert raw != _FULL_WIDTH, "value must be JSON, not a plain string"


### PR DESCRIPTION
This pull request updates the way Confluence page appearance metadata is serialized and stored, ensuring it is always written as a JSON object rather than a plain string. It also improves the pre-commit workflow to only run checks on changed files, and adds comprehensive tests for the new appearance serialization logic.

**Confluence page appearance serialization:**

* The `page_width` property in `_apply_page_metadata` is now serialized as a JSON object (e.g., `{"layout": "full-width"}`) instead of a plain string when setting appearance properties. This ensures compatibility with Confluence's expected data format.
* Added `import json` to the relevant module to support the new serialization logic.

**Testing improvements:**

* Added a new test module `test_page_metadata.py` with thorough tests to verify that appearance properties are set as JSON objects, both published and draft keys are handled, and that no appearance property is set when `page_width` is `None`.

**Pre-commit workflow optimization:**

* Updated the `.github/workflows/pre-commit.yaml` workflow to compute changed files between the PR base and head, and run pre-commit hooks only on those files. This reduces unnecessary checks and speeds up CI runs.